### PR TITLE
Finished production setup

### DIFF
--- a/DragonLoopAPI/Dockerfile
+++ b/DragonLoopAPI/Dockerfile
@@ -1,21 +1,19 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.0-buster-slim AS base
-WORKDIR /app
-EXPOSE 80
-
 FROM mcr.microsoft.com/dotnet/core/sdk:3.0-buster AS build
-WORKDIR /src
-COPY ./DragonLoopAPI/DragonLoopAPI.csproj DragonLoopAPI/
-RUN dotnet restore "DragonLoopAPI/DragonLoopAPI.csproj"
-COPY . .
-WORKDIR "/src/DragonLoopAPI"
-RUN dotnet build "DragonLoopAPI.csproj" -c Release -o /app/build
-RUN dotnet user-secrets set "PgConnectionString" "Server=db;Port=5432;User Id=postgres;Password=password;Database=postgres;"
+WORKDIR /src/DragonLoopAPI
+COPY ./DragonLoopModels ../DragonLoopModels
+COPY DragonLoopAPI/DragonLoopAPI.csproj ./
+RUN dotnet restore "DragonLoopAPI.csproj"
+COPY ./DragonLoopAPI .
+
+
+FROM build as dev
+RUN dotnet build "DragonLoopAPI.csproj" -c Development -o /app/build
 ENTRYPOINT [ "dotnet", "watch", "run"]
 
 FROM build AS publish
 RUN dotnet publish "DragonLoopAPI.csproj" -c Release -o /app/publish
 
-FROM base AS final
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.0-buster-slim AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "DragonLoopAPI.dll"]

--- a/DragonLoopAPI/Properties/launchSettings.json
+++ b/DragonLoopAPI/Properties/launchSettings.json
@@ -7,7 +7,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://0.0.0.0:5001"
+      "applicationUrl": "http://0.0.0.0:80"
     }
   }
 }

--- a/DragonLoopAPI/Startup.cs
+++ b/DragonLoopAPI/Startup.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
-using System.Environment;
+using System;
 
 namespace DragonLoopAPI
 {
@@ -25,7 +25,7 @@ namespace DragonLoopAPI
             services.AddControllers()
                     .AddNewtonsoftJson(options => options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore);
 
-            string pg_con_string = GetEnvironmentVariable("PG_CONNECTION_STRING");
+            string pg_con_string = Environment.GetEnvironmentVariable("PG_CONNECTION_STRING");
             if (pg_con_string == "")
             {
                 pg_con_string = Configuration.GetSection("PgConnectionString").Value;

--- a/DragonLoopAPI/Startup.cs
+++ b/DragonLoopAPI/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using System.Environment;
 
 namespace DragonLoopAPI
 {
@@ -23,10 +24,14 @@ namespace DragonLoopAPI
         {
             services.AddControllers()
                     .AddNewtonsoftJson(options => options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore);
-                             
 
+            string pg_con_string = GetEnvironmentVariable("PG_CONNECTION_STRING");
+            if (pg_con_string == "")
+            {
+                pg_con_string = Configuration.GetSection("PgConnectionString").Value;
+            }
             services.AddEntityFrameworkNpgsql()
-                    .AddDbContext<DragonLoopContext>(context => context.UseLazyLoadingProxies().UseNpgsql(Configuration.GetSection("PgConnectionString").Value));
+                    .AddDbContext<DragonLoopContext>(context => context.UseLazyLoadingProxies().UseNpgsql(pg_con_string));
 
             services.AddSwaggerGen(c =>
             {

--- a/DragonLoopAPI/appsettings.json
+++ b/DragonLoopAPI/appsettings.json
@@ -5,5 +5,5 @@
     }
   },
   "AllowedHosts": "*",
-  "PgConnectionString": ""
+  "PgConnectionString": "User ID=postgres;Host=db;Port=5432;Database=postgres;"
 }

--- a/DragonLoopWeb/Dockerfile
+++ b/DragonLoopWeb/Dockerfile
@@ -1,27 +1,19 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.0-buster-slim AS base
-WORKDIR /app
-EXPOSE 80
-EXPOSE 443
-
 FROM mcr.microsoft.com/dotnet/core/sdk:3.0-buster AS build
 WORKDIR /src/DragonLoopWeb
-EXPOSE 55495
-COPY DragonLoopWeb/*.csproj ./
-RUN dotnet restore
-#RUN dotnet restore "DragonLoopWeb.csproj"
-COPY ./DragonLoopWeb .
-COPY ./DragonLoopModels/ ../DragonLoopModels
+COPY ./DragonLoopModels ../DragonLoopModels
 COPY ./DragonLoopViewModels ../DragonLoopViewModels
-RUN dotnet build "DragonLoopWeb.csproj" -c Debug -o /app/build
+COPY DragonLoopWeb/DragonLoopWeb.csproj .
+RUN dotnet restore "DragonLoopWeb.csproj"
+COPY ./DragonLoopWeb/ .
+
+FROM build as dev
+RUN dotnet build "DragonLoopWeb.csproj" -c Development -o /app/build
 ENTRYPOINT [ "dotnet", "watch", "run"]
 
 FROM build AS publish
-RUN dotnet publish "DragonLoopWeb.csproj" --self-contained -c Release -o /app/publish
-#ENTRYPOINT [ "bash" ]
+RUN dotnet publish "DragonLoopWeb.csproj" -c Release -o /app/publish
 
-FROM base AS final
-WORKDIR /app
-COPY --from=publish /app/publish .
-#ENTRYPOINT [ "bash" ]
-ENTRYPOINT ["dotnet", "DragonLoopWeb.dll"]
-
+FROM nginx:alpine AS final
+WORKDIR /usr/share/nginx/html
+COPY --from=publish /app/publish/DragonLoopWeb/dist .
+COPY ./DragonLoopWeb/nginx.conf /etc/nginx/nginx.conf

--- a/DragonLoopWeb/Pages/Map.razor
+++ b/DragonLoopWeb/Pages/Map.razor
@@ -1,6 +1,8 @@
 ﻿@page "/"
 @using DragonLoopViewModels.ViewModels
 @inject IJSRuntime JsRuntime;
+@using Microsoft.AspNetCore.Components;
+@inject NavigationManager MyNavigationManager
 
 <h1>Maps View</h1>
 
@@ -32,11 +34,14 @@ else
 }
 
 @code {
-    private MapViewModel mapViewModel = new MapViewModel(Settings.UrlBase);
+    private MapViewModel mapViewModel;
     private ElementReference map;
 
     protected override async Task OnInitializedAsync()
-        => await mapViewModel.LoadRoutes();
+    {
+            mapViewModel = new MapViewModel(MyNavigationManager.BaseUri + "/api");
+            await mapViewModel.LoadRoutes();
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
         => await JsRuntime.InvokeAsync<object>

--- a/DragonLoopWeb/Pages/Schedules.razor
+++ b/DragonLoopWeb/Pages/Schedules.razor
@@ -1,5 +1,7 @@
 ﻿@page "/schedules"
 @using DragonLoopViewModels.ViewModels
+@using Microsoft.AspNetCore.Components;
+@inject NavigationManager MyNavigationManager
 
 <h1>Schedules</h1>
 
@@ -35,10 +37,11 @@ else
 }
 
 @code {
-    private ScheduleViewModel scheduleViewModel = new ScheduleViewModel(Settings.UrlBase);
+    private ScheduleViewModel scheduleViewModel;
 
     protected override async Task OnInitializedAsync()
     {
+        scheduleViewModel = new ScheduleViewModel(MyNavigationManager.BaseUri + "/api");
         await scheduleViewModel.LoadRoutes();
         await scheduleViewModel.SetSelectedRoute(scheduleViewModel.Routes.First());
     }

--- a/DragonLoopWeb/Properties/launchSettings.json
+++ b/DragonLoopWeb/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://0.0.0.0:55495/"
+      "applicationUrl": "http://0.0.0.0:80"
     }
   }
 }

--- a/DragonLoopWeb/Settings.cs
+++ b/DragonLoopWeb/Settings.cs
@@ -2,6 +2,6 @@
 {
     public static class Settings
     {
-        public const string UrlBase = "http://localhost:5001";
+
     }
 }

--- a/DragonLoopWeb/nginx.conf
+++ b/DragonLoopWeb/nginx.conf
@@ -1,0 +1,16 @@
+events { }
+http {
+    include mime.types;
+    types {
+        application/wasm wasm;
+    }
+
+    server {
+        listen 80;
+
+        location / {
+            root /usr/share/nginx/html;
+            try_files $uri $uri/ /index.html =404;
+        }
+    }
+}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,3 +4,13 @@ services:
   dragonloopapi:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+    volumes:
+      - "./DragonLoopApi:/src/DragonLoopApi"
+
+  dragonloopweb:
+    volumes:
+      - "./DragonLoopWeb:/src/DragonLoopWeb"
+
+  db:
+    ports:
+      - "5432:5432"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,15 @@
+version: "3.7"
+
+services:
+  dragonloopapi:
+    image: docker.pkg.github.com/dragon-loop/dragonloop/dragonloopapi:latest
+    build:
+      target: final
+
+  dragonloopweb:
+    image: docker.pkg.github.com/dragon-loop/dragonloop/dragonloopweb:latest
+    build:
+      target: final
+
+  nginx:
+    image: docker.pkg.github.com/dragon-loop/dragonloop/nginx:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,32 +3,36 @@ version: "3.7"
 services:
   dragonloopapi:
     image: ${DOCKER_REGISTRY-}dragonloopapi${TAG-}
+    ports:
+      - 5000:80
     build:
-      target: build
+      target: dev
       context: .
       dockerfile: DragonLoopAPI/Dockerfile
-    volumes:
-      - "./:/src/"
-    ports:
-      - "5001:5001"
+    depends_on:
+      - db
 
   dragonloopweb:
     image: ${DOCKER_REGISTRY-}dragonloopweb${TAG-}
+    ports:
+      - 8000:80
     build:
-      target: build
+      target: dev
       context: .
       dockerfile: DragonLoopWeb/Dockerfile
-    volumes:
-      - "./:/src/"
-    ports:
-      - "80:55495"
 
   db:
     image: postgres:12-alpine
     volumes:
       - db-data:/var/lib/postgresql/data
+
+  nginx:
+    image: ${DOCKER_REGISTRY-}nginx${TAG-}
+    build:
+      context: ./nginx
     ports:
-      - "5432:5432"
+      - 80:80
+    restart: always
 
 volumes:
   db-data:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:1.17.0-alpine
+
+#RUN rm /etc/nginx/conf.d/default.conf
+COPY ./nginx.conf /etc/nginx/nginx.conf
+#RUN chmod 777 /etc/nginx/conf.d/nginx.conf

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,23 @@
+events { }
+http {
+    include /etc/nginx/mime.types;
+    proxy_connect_timeout 900;
+    proxy_read_timeout 900;
+    proxy_send_timeout 900;
+    send_timeout 900;
+    client_header_timeout 900;
+    client_body_timeout 900;
+    server {
+        listen 80;
+        location / {
+            proxy_pass http://dragonloopweb:80;
+            proxy_redirect default;
+            proxy_http_version 1.1;
+        }
+        location ~ /api/ {
+            proxy_pass http://dragonloopapi:80;
+            proxy_redirect default;
+            proxy_http_version 1.1;
+        }
+    }
+}


### PR DESCRIPTION
Changes:

- nginx reverse proxy
- Frontend uses current url as a base instead of hardcoded setting, there's probably a way to do this with less boilerplate
- API grabs postgres string from environment variable before falling back on whats in appsettings.json
- Changed applicationUrl for api and web to use 0.0.0.0:80, since they're both behind nginx they can both use port 80. We can change this if it conflicts with anyone's dev process
